### PR TITLE
Brings reliability to both ways synchronization process

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -165,6 +165,8 @@ dependencies {
     // Retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.3.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.2.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.4.1'
+
 
     //Soft keyboard listener
     implementation 'net.yslibrary.keyboardvisibilityevent:keyboardvisibilityevent:2.1.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,8 @@
             android:windowSoftInputMode="adjustResize">
         </activity>
         <activity android:name="org.fundacionparaguaya.adviserplatform.ui.dashboard.DashActivity"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:launchMode="singleTop">
         </activity>
         <activity android:name="org.fundacionparaguaya.adviserplatform.ui.login.LoginActivity"
             android:windowSoftInputMode="adjustResize">

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/AdviserApplication.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/AdviserApplication.java
@@ -98,4 +98,5 @@ public class AdviserApplication extends MultiDexApplication {
 
         mMerlin.unbind();
     }
+
 }

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Login.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Login.java
@@ -13,16 +13,22 @@ public class Login {
     private String tokenType;
     private int expiresIn;
     private String refreshToken;
+    private User user;
 
     public Login(String refreshToken) {
         this.refreshToken = refreshToken;
     }
 
     public Login(String accessToken, String tokenType, int expiresIn, String refreshToken) {
+        this(accessToken, tokenType, expiresIn, refreshToken, null);
+    }
+
+    public Login(String accessToken, String tokenType, int expiresIn, String refreshToken, User user) {
         this.accessToken = accessToken;
         this.tokenType = tokenType;
         this.expiresIn = expiresIn;
         this.refreshToken = refreshToken;
+        this.user = user;
     }
 
     public String getAccessToken() {
@@ -45,33 +51,56 @@ public class Login {
         return refreshToken;
     }
 
-    @Override
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
+    public User getUser() {
+        return user;
     }
 
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Login that = (Login) o;
-
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        Login rhs = (Login) obj;
         return new EqualsBuilder()
-                .append(accessToken, that.accessToken)
-                .append(tokenType, that.tokenType)
-                .append(expiresIn, that.expiresIn)
-                .append(refreshToken, that.refreshToken)
+                .append(this.accessToken, rhs.accessToken)
+                .append(this.tokenType, rhs.tokenType)
+                .append(this.expiresIn, rhs.expiresIn)
+                .append(this.refreshToken, rhs.refreshToken)
+                .append(this.user, rhs.user)
                 .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 97)
+        return new HashCodeBuilder()
                 .append(accessToken)
                 .append(tokenType)
                 .append(expiresIn)
                 .append(refreshToken)
+                .append(user)
                 .toHashCode();
+    }
+
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("accessToken", accessToken)
+                .append("tokenType", tokenType)
+                .append("expiresIn", expiresIn)
+                .append("refreshToken", refreshToken)
+                .append("user", user)
+                .toString();
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Organization.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Organization.java
@@ -1,0 +1,58 @@
+package org.fundacionparaguaya.adviserplatform.data.model;
+
+public class Organization {
+    private Long id;
+    private String name;
+    private String code;
+    private String description;
+    private String country;
+    private String information;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getInformation() {
+        return information;
+    }
+
+    public void setInformation(String information) {
+        this.information = information;
+    }
+}

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Snapshot.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Snapshot.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.text.format.DateUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.fundacionparaguaya.adviserplatform.data.local.Converters;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
@@ -61,6 +62,9 @@ public class Snapshot implements Comparable<Snapshot>{
 
     @Ignore
     boolean mIsLatest;
+
+    @Ignore
+    private Long organizationId;
 
     @Ignore
     public Snapshot(Survey survey) {
@@ -234,6 +238,8 @@ public class Snapshot implements Comparable<Snapshot>{
 
     @Override
     public String toString() {
+        //TODO Sodep: This should be a different method for ListModels. Pretty time is not a string
+        //TODO Sodep: representation of this object
         String dateString;
 
         if(DateUtils.isToday(createdAt.getTime()))
@@ -259,30 +265,52 @@ public class Snapshot implements Comparable<Snapshot>{
         mIsLatest = isLatest;
     }
 
+
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public int compareTo(@NonNull Snapshot snapshot) {
+        return this.getCreatedAt().compareTo(snapshot.getCreatedAt());
+    }
 
-        Snapshot that = (Snapshot) o;
+    public void setOrganizationId(Long organizationId) {
+        this.organizationId = organizationId;
+    }
 
+    public Long getOrganizationId() {
+        return organizationId;
+    }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        Snapshot rhs = (Snapshot) obj;
         return new EqualsBuilder()
-                .append(id, that.id)
-                .append(remoteId, that.remoteId)
-                .append(familyId, that.familyId)
-                .append(surveyId, that.surveyId)
-                .append(inProgress, that.inProgress)
-                .append(personalResponses, that.personalResponses)
-                .append(economicResponses, that.economicResponses)
-                .append(indicatorResponses, that.indicatorResponses)
-                .append(priorities, that.priorities)
-                .append(createdAt, that.createdAt)
+                .append(this.id, rhs.id)
+                .append(this.remoteId, rhs.remoteId)
+                .append(this.familyId, rhs.familyId)
+                .append(this.surveyId, rhs.surveyId)
+                .append(this.inProgress, rhs.inProgress)
+                .append(this.personalResponses, rhs.personalResponses)
+                .append(this.economicResponses, rhs.economicResponses)
+                .append(this.indicatorResponses, rhs.indicatorResponses)
+                .append(this.priorities, rhs.priorities)
+                .append(this.createdAt, rhs.createdAt)
+                .append(this.mIsLatest, rhs.mIsLatest)
+                .append(this.organizationId, rhs.organizationId)
                 .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(41, 59)
+        return new HashCodeBuilder()
                 .append(id)
                 .append(remoteId)
                 .append(familyId)
@@ -293,11 +321,12 @@ public class Snapshot implements Comparable<Snapshot>{
                 .append(indicatorResponses)
                 .append(priorities)
                 .append(createdAt)
+                .append(mIsLatest)
+                .append(organizationId)
                 .toHashCode();
     }
 
-    @Override
-    public int compareTo(@NonNull Snapshot snapshot) {
-        return this.getCreatedAt().compareTo(snapshot.getCreatedAt());
+    public void setPriorities(List<LifeMapPriority> priorities) {
+        this.priorities = priorities;
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/User.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/User.java
@@ -12,6 +12,7 @@ public class User {
     private String username;
     private String password;
     private Login login;
+    private Organization organization;
 
     public User(String username, String password, Login login) {
         this.username = username;
@@ -35,6 +36,46 @@ public class User {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        User rhs = (User) obj;
+        return new EqualsBuilder()
+                .append(this.username, rhs.username)
+                .append(this.password, rhs.password)
+                .append(this.login, rhs.login)
+                .append(this.organization, rhs.organization)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(username)
+                .append(password)
+                .append(login)
+                .append(organization)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("username", username)
+                .append("password", password)
+                .append("login", login)
+                .append("organization", organization)
+                .toString();
     }
 
     public static class Builder {
@@ -62,32 +103,6 @@ public class User {
         }
     }
 
-    @Override
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        User that = (User) o;
-
-        return new EqualsBuilder()
-                .append(username, that.username)
-                .append(login, that.login)
-                .isEquals();
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder(31, 13)
-                .append(username)
-                .append(login)
-                .toHashCode();
-    }
-
     public void setUsername(String username) {
         this.username = username;
     }
@@ -95,4 +110,14 @@ public class User {
     public void setPassword(String password) {
         this.password = password;
     }
+
+    public Organization getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(Organization organization) {
+        this.organization = organization;
+    }
+
+
 }

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/remote/AuthenticationManager.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/remote/AuthenticationManager.java
@@ -35,10 +35,6 @@ import static org.fundacionparaguaya.adviserplatform.data.remote.AuthenticationM
 @Singleton
 public class AuthenticationManager {
     public static final String TAG = "AuthManager";
-    static final String KEY_REFRESH_TOKEN = "refreshToken";
-    static final String KEY_USERNAME = "username";
-    private static final String AUTH_KEY = "Basic " + BuildConfig.POVERTY_STOPLIGHT_API_KEY_STRING;
-    private static final String KEY_TOKEN_EXPIRATION = "KEY_TOKEN_EXPIRATION";
 
     public enum AuthenticationStatus {
         UNKNOWN,
@@ -92,19 +88,24 @@ public class AuthenticationManager {
      * Attempts to login with the stored credentials, if any exist. This will update the status.
      */
     public AuthenticationStatus login() {
-        String refreshToken = mPreferences.getString(KEY_REFRESH_TOKEN, null);
-        String username = mPreferences.getString(KEY_USERNAME, null);
-        if (AuthenticationManager.isTokenExpired(mPreferences)
-                || refreshToken != null && username != null)
-            return refreshLogin(refreshToken, username);
-        else
-            return updateStatus(UNAUTHENTICATED);
+        AuthenticationStatus authenticationStatus = UNAUTHENTICATED;
+        //TODO Sodep: Re-auth with refresh token is not working, throws a BAD_REQUEST response
+        String refreshToken = mPreferences.getString(AppConstants.KEY_REFRESH_TOKEN, null);
+        String username = mPreferences.getString(AppConstants.KEY_USERNAME, null);
+        if (refreshToken != null && username != null &&
+                !AuthenticationManager.isTokenExpired(mPreferences)) {
+            authenticationStatus = refreshLogin(refreshToken, username);
+        }
+        if(UNAUTHENTICATED.equals(authenticationStatus)) {
+            authenticationStatus = refreshLogin();
+        }
+        return authenticationStatus;
     }
 
     public static boolean isTokenExpired(SharedPreferences mPreferences) {
         Date now = new Date();
         final long yesterday = DateUtils.addDays(new Date(), -1).getTime();
-        Long expirationTimeStamp = mPreferences.getLong(KEY_TOKEN_EXPIRATION,
+        Long expirationTimeStamp = mPreferences.getLong(AppConstants.KEY_TOKEN_EXPIRATION,
                 yesterday);
         final Date expirationDate = new Date(expirationTimeStamp);
         Log.d(TAG, String.format("Token is valid until: %s", expirationDate));
@@ -128,9 +129,15 @@ public class AuthenticationManager {
      * Attempts to refresh the login using a saved refresh token.
      */
     private AuthenticationStatus refreshLogin(String refreshToken, String username) {
+        String encryptedPassword = mPreferences.getString(KEY_PASSWORD, null);
+        String password = null;
+        if(StringUtils.isNotBlank(encryptedPassword)) {
+            password = SecurityUtils.decrypt(encryptedPassword);
+        }
         if (mConnectivityWatcher.isOffline()) {
             mUser = User.builder()
                     .username(username)
+                    .password(password)
                     .login(new Login(refreshToken))
                     .build();
             return updateStatus(AUTHENTICATED);//assume authenticated because there is refresh token
@@ -139,22 +146,24 @@ public class AuthenticationManager {
             updateStatus(PENDING);
             retrofit2.Response<LoginIr> response = mAuthService
                     .loginWithRefreshToken(
-                            AUTH_KEY,
+                            AppConstants.AUTH_KEY,
                             refreshToken).execute();
 
-            return updateLogin(User.builder().username(username).build(), response);
+            return updateLogin(User.builder()
+                    .username(username)
+                    .password(password).build(), response);
         } catch (IOException e) {
             Log.e(TAG, "refreshToken: Could not refresh the token!", e);
             return updateStatus(UNAUTHENTICATED);
         }
     }
 
-    private AuthenticationStatus getToken(User user) {
+    public AuthenticationStatus getToken(User user) {
         if (user == null) {
             return updateStatus(UNAUTHENTICATED);
         }
         try {
-            updateStatus(PENDING);
+            //updateStatus(PENDING);
             String password = user.getPassword();
             if (StringUtils.isBlank(password)) {
                 String encrypted = mPreferences.getString(KEY_PASSWORD, null);
@@ -167,7 +176,7 @@ public class AuthenticationManager {
             }
             retrofit2.Response<LoginIr> response = mAuthService
                     .loginWithPassword(
-                            AUTH_KEY,
+                            AppConstants.AUTH_KEY,
                             user.getUsername(),
                             password).execute();
             if (AppConstants.HTTP_SC_BAD_REQUEST == response.code()) {
@@ -189,6 +198,7 @@ public class AuthenticationManager {
                 mUser = user;
                 mUser.setLogin(newLogin);
             }
+            mUser.setOrganization(newLogin.getUser().getOrganization());
             saveLogin();
             return updateStatus(AUTHENTICATED);
         } else {
@@ -202,9 +212,10 @@ public class AuthenticationManager {
         final int expiresInSeconds = mUser.getLogin().getExpiresIn();
         final Date expirationDate = DateUtils.addSeconds(new Date(), expiresInSeconds);
 
-        editor.putString(KEY_REFRESH_TOKEN, mUser.getLogin().getRefreshToken());
-        editor.putString(KEY_USERNAME, mUser.getUsername());
-        editor.putLong(KEY_TOKEN_EXPIRATION, expirationDate.getTime());
+        editor.putString(AppConstants.KEY_REFRESH_TOKEN, mUser.getLogin().getRefreshToken());
+        editor.putString(AppConstants.KEY_USERNAME, mUser.getUsername());
+        editor.putLong(AppConstants.KEY_TOKEN_EXPIRATION, expirationDate.getTime());
+        editor.putLong(AppConstants.ORGANIZATION_ID, mUser.getOrganization().getId());
         if (StringUtils.isNotBlank(mUser.getPassword())) {
             editor.putString(KEY_PASSWORD, SecurityUtils.encrypt(mUser.getPassword()));
         } else {
@@ -216,10 +227,12 @@ public class AuthenticationManager {
 
     private void clearLogin() {
         SharedPreferences.Editor editor = mPreferences.edit();
-        editor.remove(KEY_REFRESH_TOKEN);
-        editor.remove(KEY_USERNAME);
+        editor.remove(AppConstants.KEY_REFRESH_TOKEN);
+        //We don't delete username yet, if same user comes back; data should still be available
+        //editor.remove(AppConstants.KEY_USERNAME);
         editor.remove(KEY_PASSWORD);
-        editor.remove(KEY_TOKEN_EXPIRATION);
+        editor.remove(AppConstants.KEY_TOKEN_EXPIRATION);
+        editor.remove(AppConstants.ORGANIZATION_ID);
         editor.apply();
     }
 
@@ -265,9 +278,16 @@ public class AuthenticationManager {
         void onAuthStateChange(AuthenticationManager.AuthenticationStatus status);
     }
 
-    public AuthenticationStatus refreshToken() {
+    public AuthenticationStatus refreshLogin() {
+        String userName = mPreferences.getString(AppConstants.KEY_USERNAME, null);
+        String encrypted = mPreferences.getString(KEY_PASSWORD, null);
+        String password = SecurityUtils.decrypt(encrypted);
+        if(mUser == null) {
+            mUser = User.builder().username(userName).password(password).build();
+        }
+        mUser.setUsername(userName);
+        mUser.setPassword(password);
         return login(mUser);
     }
-
 
 }

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/remote/intermediaterepresentation/IrMapper.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/remote/intermediaterepresentation/IrMapper.java
@@ -47,7 +47,7 @@ public class IrMapper {
 
     //region Login
     public static Login mapLogin(LoginIr ir) {
-        return new Login(ir.accessToken, ir.tokenType, ir.expiresIn, ir.refreshToken);
+        return new Login(ir.accessToken, ir.tokenType, ir.expiresIn, ir.refreshToken, ir.user);
     }
     //endregion Login
 
@@ -378,7 +378,7 @@ public class IrMapper {
         return responses;
     }
 
-    private static List<LifeMapPriority> mapPriorities(List<PriorityIr> ir, Survey survey) {
+    public static List<LifeMapPriority> mapPriorities(List<PriorityIr> ir, Survey survey) {
         if (ir == null) return Collections.emptyList();
 
         List<LifeMapPriority> priorities = new ArrayList<>(ir.size());

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/remote/intermediaterepresentation/LoginIr.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/remote/intermediaterepresentation/LoginIr.java
@@ -2,6 +2,8 @@ package org.fundacionparaguaya.adviserplatform.data.remote.intermediaterepresent
 
 import com.google.gson.annotations.SerializedName;
 
+import org.fundacionparaguaya.adviserplatform.data.model.User;
+
 /**
  * The intermediate representation of a login from the remote database.
  */
@@ -15,4 +17,5 @@ public class LoginIr {
     int expiresIn;
     @SerializedName("refresh_token")
     String refreshToken;
+    User user;
 }

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/repositories/FamilyRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/repositories/FamilyRepository.java
@@ -20,6 +20,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.lang.String.format;
 
@@ -82,19 +83,22 @@ public class FamilyRepository extends BaseRepository {
      * Synchronizes the local families with the remote database.
      * @return Whether the sync was successful.
      */
-    public boolean sync(@Nullable Date lastSync) {
-        boolean result = pullFamilies(lastSync);
+    @Override
+    public boolean sync() {
+        boolean result = pullFamilies();
         clearSyncStatus();
 
         return result;
     }
 
     public void clean() {
+        setmIsAlive(new AtomicBoolean(false));
         familyDao.deleteAll();
         setRecordsCount(0);
     }
 
-    private boolean pullFamilies(@Nullable Date lastSync) {
+    private boolean pullFamilies() {
+        Date lastSync = getLastSyncDate() > 0 ? new Date(getLastSyncDate()) : null;
         long loopCount = 0;
         try {
             //TODO Sodep: why ask here and again inside family loop?

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/repositories/ImageRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/repositories/ImageRepository.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * The utility for the storage of snapshots.
@@ -46,7 +47,8 @@ public class ImageRepository extends BaseRepository {
      * Synchronizes the local snapshots with the remote database.
      * @return Whether the sync was successful.
      */
-    public boolean sync(@Nullable Date lastSync) {
+    @Override
+    public boolean sync() {
         long loopCount = 0;
         //TODO Sodep: How many times does images really change to make this sync as frequent as others?
         boolean result = true;
@@ -70,8 +72,10 @@ public class ImageRepository extends BaseRepository {
                         Uri uri = Uri.parse(option.getImageUrl());
                         imagesDownloaded.add(uri);
                         result &= downloadImage(uri);
-                        getDashActivity().setSyncLabel(R.string.syncing_images, ++loopCount,
-                                getRecordsCount());
+                        if(getDashActivity() != null) {
+                            getDashActivity().setSyncLabel(R.string.syncing_images, ++loopCount,
+                                    getRecordsCount());
+                        }
 
                     }
                 }
@@ -144,6 +148,7 @@ public class ImageRepository extends BaseRepository {
     }
 
     public void clean() {
+        setmIsAlive(new AtomicBoolean(false));
         Fresco.getImagePipeline().clearCaches();
         Fresco.getImagePipeline().clearDiskCaches();
         setRecordsCount(0);

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/repositories/SurveyRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/repositories/SurveyRepository.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.lang.String.format;
 
@@ -70,7 +71,8 @@ public class SurveyRepository extends BaseRepository{
         }
     }
 
-    private boolean pullSurveys(@Nullable Date lastSync) {
+    private boolean pullSurveys() {
+        Date lastSync = getLastSyncDate() > 0 ? new Date(getLastSyncDate()) : null;
         long loopCount = 0;
 
         try {
@@ -120,11 +122,13 @@ public class SurveyRepository extends BaseRepository{
      * Synchronizes the local surveys with the remote database.
      * @return Whether the sync was successful.
      */
-    boolean sync(@Nullable Date lastSync) {
-        return pullSurveys(lastSync);
+    @Override
+    public boolean sync() {
+        return pullSurveys();
     }
 
     public void clean() {
+        setmIsAlive(new AtomicBoolean(false));
         surveyDao.deleteAll();
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/injection/ApplicationModule.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/injection/ApplicationModule.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import dagger.Module;
 import dagger.Provides;
 import org.fundacionparaguaya.adviserplatform.AdviserApplication;
+import org.fundacionparaguaya.adviserplatform.util.AppConstants;
 import org.fundacionparaguaya.adviserplatform.util.MixpanelHelper;
 
 import javax.inject.Singleton;
@@ -18,7 +19,6 @@ import static android.content.Context.MODE_PRIVATE;
 
 @Module
 public class ApplicationModule {
-    private static final String SHARED_PREFS_NAME = "advisor_app";
 
     private final Application application;
 
@@ -35,7 +35,7 @@ public class ApplicationModule {
     @Provides
     @Singleton
     SharedPreferences provideSharedPreferences(Application application) {
-        return application.getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE);
+        return application.getSharedPreferences(AppConstants.SHARED_PREFS_NAME, MODE_PRIVATE);
     }
 
     @Provides

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/activities/SplashActivity.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/activities/SplashActivity.java
@@ -85,6 +85,7 @@ public class SplashActivity extends BaseCompatActivity {
                     .apply();
         } else {
             nextActivity = new Intent(context, DashActivity.class);
+            nextActivity.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         }
 
         context.startActivity(nextActivity);

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/survey/TakeSurveyFragment.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/survey/TakeSurveyFragment.java
@@ -2,6 +2,7 @@ package org.fundacionparaguaya.adviserplatform.ui.survey;
 
 import android.app.Activity;
 import android.arch.lifecycle.ViewModelProviders;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -18,6 +19,7 @@ import org.fundacionparaguaya.adviserplatform.R;
 import org.fundacionparaguaya.adviserplatform.injection.InjectionViewModelFactory;
 import org.fundacionparaguaya.adviserplatform.ui.dashboard.DashActivity;
 import org.fundacionparaguaya.adviserplatform.ui.survey.SharedSurveyViewModel.SurveyState;
+import org.fundacionparaguaya.adviserplatform.util.AppConstants;
 import org.fundacionparaguaya.adviserplatform.util.KeyboardUtils;
 import org.fundacionparaguaya.adviserplatform.util.MixpanelHelper;
 
@@ -143,6 +145,7 @@ public class TakeSurveyFragment extends Fragment implements  StepperLayout.Stepp
             getActivity().setResult(Activity.RESULT_OK, result);
 
             mSurveyViewModel.submitSnapshotAsync();
+            mSurveyViewModel.mSnapshotRespository.forceNextSync();
             getActivity().finish();
         });
 

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/util/AppConstants.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/util/AppConstants.java
@@ -2,12 +2,21 @@ package org.fundacionparaguaya.adviserplatform.util;
 
 import android.support.v7.app.AppCompatActivity;
 
+import org.fundacionparaguaya.adviserplatform.BuildConfig;
+
 public class AppConstants {
     public static final String FIRST_TIME_USER_KEY = "FIRST_TIME_USER_KEY";
     public static final String KEY_LAST_SYNC_TIME = "lastSyncTime";
     public static final int HTTP_SC_UNAUTHORIZED = 401;
     public static final int HTTP_SC_BAD_REQUEST = 400;
     public static final int TOTAL_TYPES_OF_INDICATORS = 3;
+    public static final String SHARED_PREFS_NAME = "advisor_app";
+    public static final String KEY_REFRESH_TOKEN = "refreshToken";
+    public static final String KEY_USERNAME = "username";
+    public static final String AUTH_KEY = "Basic " + BuildConfig.POVERTY_STOPLIGHT_API_KEY_STRING;
+    public static final String KEY_TOKEN_EXPIRATION = "KEY_TOKEN_EXPIRATION";
+    public static final String ORGANIZATION_ID = "ORGANIZATION_ID";
+
 
     private AppConstants() {
         //Utilities classes don't have public constructors

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,4 +139,5 @@
     <string name="syncing_surveys">Syncing %d of %d surveys</string>
     <string name="syncing_snapshots">Syncing %d of %d snapshots</string>
     <string name="syncing_images">Syncing %d of %d images</string>
+    <string name="login_error">Wrong credentials</string>
 </resources>


### PR DESCRIPTION
- Adds `Organization.java` pojo
- Mapping of User and Organization data is being made form login API response
- Adds organization data to `Snapshot.java` model and User.java model
- Adds User information to Login API response
- Authentication constants are centralized in `AppConstants.java` 
- Adds another chance to recover from lost login with stores credentials
  besides refreshing auth token
- Stores token expiration time to check for its validity
- Stores encrypted credentials data in user preferences
- WIP: Data is erased from device only if a different user is logged in
- Families are pulled from server using user organization as a filter
- `BaseRepository.java` handles its own repository sync time
- Each repository handles how many records are about to be sync and
  progress status/sync count.
- Sync condition is based on each repository status
- Feedback is provided  in Dash status about sync progress for
  `FamilyRepository.java`, `SurveyRepository.java`, `SnapshotRepository.java`
  and `ImageRepository.java`
- Snapshots are saved with Organization information, to correctly get
  all the info filtered by User's Organization
- Removes `continue` sentence on errors conditions from loops where main sync
  process were being made
- If an HTTP 4xx code is received during sync process, it is raised to calling
  method
- Only deletes local snapshots if sync process finished properly
- New Snapshots (with embedded family creation) are saved/pulled with
  its Priorities properly
- Snapshots cleaning are only performed on logout if there are no
  pending ones
- Major `SyncManager.java` refactor to handle individual
  `BaseRepository.java` with login reattempt on selected 4xx codes
  received
- Sync process is stopped when http status 4xx is received and
  authentication could not be restored
- Sync date status is based on last `BaseRepository.java` successfull sync
- User local data cleanning is only performed if there are no
  credentials data stored
- All of `BaseRepository.java` and `SyncJob.java` alive status is tied to global sync process
- Adds logger interceptor for better debugging REST API calls
- Sync time is set to 30 minutes
- `SyncJob.java` retries login on unexpected `UNAUTHENTICATED` events with
  stored credentials
- DashActivity should be unique, to do that it is made a `CLEAR_TOP` and
  singleTop singleTop
- When a survey is completed, `SnapshotRepository.java` is forced to be
  synced in next cycle