### PR TITLE
Validation to prevent user from logging out

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 27
         multiDexEnabled true
-        versionCode 16
+        versionCode 17
         versionName versioning.info.display
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/repositories/SnapshotRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/repositories/SnapshotRepository.java
@@ -374,6 +374,10 @@ public class SnapshotRepository extends BaseRepository{
         return null;
     }
 
+    public List<Snapshot> getQueueSnapshots() {
+        return snapshotDao.queryPendingFinishedSnapshots();
+    }
+
     /**
      * Synchronizes the local snapshots with the remote database.
      * @return Whether the sync was successful.

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/injection/InjectionViewModelFactory.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/injection/InjectionViewModelFactory.java
@@ -55,7 +55,7 @@ public class InjectionViewModelFactory implements ViewModelProvider.Factory {
             return (T) new SharedSurveyViewModel(snapshotRepository, surveyRepository, familyRepository);
         }
         else if (modelClass.isAssignableFrom(SettingsViewModel.class)) {
-            return (T) new SettingsViewModel(authManager);
+            return (T) new SettingsViewModel(authManager, snapshotRepository);
         } else if (modelClass.isAssignableFrom(PendingSnapshotViewModel.class)) {
             return (T) new PendingSnapshotViewModel(surveyRepository, familyRepository);
         } else if(modelClass.isAssignableFrom(EditPriorityViewModel.class)){

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/settings/SettingsStackedFrag.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/settings/SettingsStackedFrag.java
@@ -2,6 +2,7 @@ package org.fundacionparaguaya.adviserplatform.ui.settings;
 
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.pm.PackageManager;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -12,11 +13,16 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
-import org.fundacionparaguaya.assistantadvisor.AdviserAssistantApplication;
-import org.fundacionparaguaya.assistantadvisor.R;
+import com.ontbee.legacyforks.cn.pedant.SweetAlert.SweetAlertDialog;
+
+import org.fundacionparaguaya.adviserplatform.data.model.Snapshot;
+import org.fundacionparaguaya.adviserplatform.injection.InjectionViewModelFactory;
 import org.fundacionparaguaya.adviserplatform.ui.base.AbstractStackedFrag;
 import org.fundacionparaguaya.adviserplatform.util.MixpanelHelper;
-import org.fundacionparaguaya.adviserplatform.injection.InjectionViewModelFactory;
+import org.fundacionparaguaya.assistantadvisor.AdviserAssistantApplication;
+import org.fundacionparaguaya.assistantadvisor.R;
+
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -30,6 +36,7 @@ public class SettingsStackedFrag extends AbstractStackedFrag {
     private TextView mUsername;
 
     private TextView mReleaseNum;
+    private Boolean queueSnapshots;
 
     protected @Inject
     InjectionViewModelFactory mViewModelFactory;
@@ -52,8 +59,8 @@ public class SettingsStackedFrag extends AbstractStackedFrag {
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.fragment_settingsmain, container, false);
 
+        View view = inflater.inflate(R.layout.fragment_settingsmain, container, false);
         mLogout = (Button) view.findViewById(R.id.settings_login_logout);
         mUsername = (TextView) view.findViewById(R.id.settings_login_username);
 
@@ -76,6 +83,9 @@ public class SettingsStackedFrag extends AbstractStackedFrag {
             version = getString(R.string.settings_releasenumber_error);
         }
         mReleaseNum.setText(version);
+
+        noSnapshotsRemainingToSync();
+
         return view;
     }
 
@@ -84,11 +94,33 @@ public class SettingsStackedFrag extends AbstractStackedFrag {
         super.onViewCreated(view, savedInstanceState);
 
         mLogout.setOnClickListener(v -> {
-
-            MixpanelHelper.LogoutEvent.logout(getContext());
-            mSettingsViewModel.getAuthManager().logout();
+            if (!queueSnapshots) {
+                makeExitDialog().show();
+            } else {
+                MixpanelHelper.LogoutEvent.logout(getContext());
+                mSettingsViewModel.getAuthManager().logout();
+            }
         });
 
     }
 
+    private void noSnapshotsRemainingToSync() {
+        AsyncTask.execute(() -> {
+            List<Snapshot> snapshots = mSettingsViewModel.getSnapshotRepository().getQueueSnapshots();
+            if(!snapshots.isEmpty()) {
+                queueSnapshots = false;
+            } else {
+                queueSnapshots = true;
+            }
+        });
+    }
+
+    private SweetAlertDialog makeExitDialog() {
+        SweetAlertDialog dialog = new SweetAlertDialog(getContext(), SweetAlertDialog.WARNING_TYPE)
+                .setTitleText(getString(R.string.logout_title))
+                .setContentText(getString(R.string.logout_description))
+                .setConfirmText(getString(R.string.all_okay))
+                .setConfirmClickListener(SweetAlertDialog::dismissWithAnimation);
+        return dialog;
+    }
 }

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/settings/SettingsViewModel.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/settings/SettingsViewModel.java
@@ -3,6 +3,7 @@ package org.fundacionparaguaya.adviserplatform.ui.settings;
 import android.arch.lifecycle.ViewModel;
 
 import org.fundacionparaguaya.adviserplatform.data.remote.AuthenticationManager;
+import org.fundacionparaguaya.adviserplatform.data.repositories.SnapshotRepository;
 
 /**
  * Created by alex on 2/11/2018.
@@ -10,13 +11,18 @@ import org.fundacionparaguaya.adviserplatform.data.remote.AuthenticationManager;
 
 public class SettingsViewModel extends ViewModel {
     private AuthenticationManager authManager;
+    private SnapshotRepository snapshotRepository;
 
-    public SettingsViewModel(AuthenticationManager authenticationManager){
+    public SettingsViewModel(AuthenticationManager authenticationManager, SnapshotRepository snapshotRepository){
         this.authManager = authenticationManager;
+        this.snapshotRepository = snapshotRepository;
     }
 
     public AuthenticationManager getAuthManager(){
         return authManager;
     }
 
+    public SnapshotRepository getSnapshotRepository() {
+        return snapshotRepository;
+    }
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -30,6 +30,9 @@
     <string name="all_cancel">Cancelar</string>
     <string name="all_confirmation_question">¿Estás seguro?</string>
 
+    <string name="logout_title">Ups! No puedes cerrar sesión</string>
+    <string name="logout_description">Por favor asegurate de tener conexión a Internet y vuelve a intentarlo más tarde</string>
+
     <!-- Login Activity -->
     <string name="login_username">Usuario</string>
     <string name="login_passwordprompt">Clave</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,9 @@
     <string name="all_cancel">Cancel</string>
     <string name="all_confirmation_question">Ready to submit?</string>
 
+    <string name="logout_title">Oops! You can\'t log out</string>
+    <string name="logout_description">Please make sure you have internet connection and try again later</string>
+
     <!-- Login Activity -->
     <string name="login_username">Username</string>
     <string name="login_passwordprompt">Password</string>


### PR DESCRIPTION
# Description <!-- [OPTIONAL] -->
If there are still snapshots that need to be syncronized, a message will
be displayed to the user letting him know that.

# Changes <!-- [REQIURED] -->
- Added a validation to prevent users from logging out when they still have snapshot queued for sync

# Screenshots <!-- [IF APPLICABLE] -->
![screenshot_1534254509](https://user-images.githubusercontent.com/28272898/44096581-9a989996-9fa9-11e8-9457-164b994800a4.png)

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [x] Logged in to the application
  - [x] Fill out a snapshot for a new family
  - [x] Fill out a snapshot for an existing family
  - [x] Fill out priorities for a snapshot
  - [x] View a family and it's priorities
- API Level:
  - [x] API Level 19
  - [ ] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [x] 7" screen size
  - [ ] 8" screen size
  - [ ] 10" screen size
