### PR TITLE
Adds warning messages when reaching limits

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 27
         multiDexEnabled true
-        versionCode 17
+        versionCode 19
         versionName versioning.info.display
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/remote/intermediaterepresentation/IrMapper.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/remote/intermediaterepresentation/IrMapper.java
@@ -13,6 +13,7 @@ import org.fundacionparaguaya.adviserplatform.data.model.Login;
 import org.fundacionparaguaya.adviserplatform.data.model.ResponseType;
 import org.fundacionparaguaya.adviserplatform.data.model.Snapshot;
 import org.fundacionparaguaya.adviserplatform.data.model.Survey;
+import org.fundacionparaguaya.adviserplatform.util.IndicatorUtilities;
 
 import java.text.CharacterIterator;
 import java.text.DateFormat;
@@ -177,7 +178,7 @@ public class IrMapper {
             for (IndicatorOptionIr optionIr : questionIr.getIndicatorOptions().values) {
                 options.add(new IndicatorOption(
                         optionIr.description,
-                        optionIr.url,
+                        IndicatorUtilities.generateUri(optionIr.url),
                         mapOptionLevel(optionIr.value)
                 ));
             }

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/repositories/ImageRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/repositories/ImageRepository.java
@@ -67,8 +67,7 @@ public class ImageRepository extends BaseRepository {
                     if(shouldAbortSync()) return false;
 
                     if (!option.getImageUrl().contains(NO_IMAGE)) {
-                        String newUri = generateUri(option.getImageUrl());
-                        Uri uri = Uri.parse(newUri);
+                        Uri uri = Uri.parse(option.getImageUrl());
                         imagesDownloaded.add(uri);
                         result &= downloadImage(uri);
                         if(getDashActivity() != null) {
@@ -86,17 +85,6 @@ public class ImageRepository extends BaseRepository {
         result &= verifyCacheResults(imagesDownloaded);
 
         return result;
-    }
-
-    private String generateUri(String imageUri) {
-        String params[] = imageUri.split("images/");
-        String uri;
-        if ( params[0].equals(AppConstants.BUCKET_FPPSP) ) {
-            uri = AppConstants.BUCKET_ENDPOINT_1;
-        } else {
-            uri = AppConstants.BUCKET_ENDPOINT_2;
-        }
-        return uri + AppConstants.RESIZE_IMAGE_SIZE + "/" + params[1];
     }
 
     private void addRecordsCount(int i) {

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/injection/InjectionViewModelFactory.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/injection/InjectionViewModelFactory.java
@@ -9,6 +9,7 @@ import org.fundacionparaguaya.adviserplatform.data.remote.ServerManager;
 import org.fundacionparaguaya.adviserplatform.data.repositories.FamilyRepository;
 import org.fundacionparaguaya.adviserplatform.data.repositories.SnapshotRepository;
 import org.fundacionparaguaya.adviserplatform.data.repositories.SurveyRepository;
+import org.fundacionparaguaya.adviserplatform.ui.dashboard.DashActivityViewModel;
 import org.fundacionparaguaya.adviserplatform.ui.families.AllFamiliesViewModel;
 import org.fundacionparaguaya.adviserplatform.ui.families.detail.FamilyDetailViewModel;
 import org.fundacionparaguaya.adviserplatform.ui.survey.SharedSurveyViewModel;
@@ -60,6 +61,8 @@ public class InjectionViewModelFactory implements ViewModelProvider.Factory {
             return (T) new PendingSnapshotViewModel(surveyRepository, familyRepository);
         } else if(modelClass.isAssignableFrom(EditPriorityViewModel.class)){
             return (T) new EditPriorityViewModel(surveyRepository);
+        } else if (modelClass.isAssignableFrom(DashActivityViewModel.class)) {
+            return (T) new DashActivityViewModel(snapshotRepository);
         }
 	else
             throw new IllegalArgumentException("The view model was not found for " + modelClass.toString());

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/dashboard/DashActivity.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/dashboard/DashActivity.java
@@ -1,16 +1,29 @@
 package org.fundacionparaguaya.adviserplatform.ui.dashboard;
 
+import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.transition.TransitionManager;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
+
 import com.github.curioustechizen.ago.RelativeTimeTextView;
+import com.ontbee.legacyforks.cn.pedant.SweetAlert.SweetAlertDialog;
+
+import org.fundacionparaguaya.adviserplatform.data.local.SnapshotDao;
+import org.fundacionparaguaya.adviserplatform.data.model.Snapshot;
+import org.fundacionparaguaya.adviserplatform.injection.InjectionViewModelFactory;
+import org.fundacionparaguaya.adviserplatform.util.AppConstants;
 import org.fundacionparaguaya.assistantadvisor.AdviserAssistantApplication;
 import org.fundacionparaguaya.assistantadvisor.BuildConfig;
 import org.fundacionparaguaya.assistantadvisor.R;
@@ -27,6 +40,8 @@ import org.fundacionparaguaya.adviserplatform.ui.settings.SettingsTabFrag;
 import org.fundacionparaguaya.adviserplatform.ui.map.MapTabFrag;
 import org.fundacionparaguaya.adviserplatform.ui.social.SocialTabFrag;
 import org.fundacionparaguaya.adviserplatform.util.MixpanelHelper;
+
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -52,12 +67,20 @@ public class DashActivity extends AbstractFragSwitcherActivity implements Displa
     SyncManager mSyncManager;
     @Inject
     AuthenticationManager mAuthManager;
+    protected @Inject
+    InjectionViewModelFactory mViewModelFactory;
+    private DashActivityViewModel mDashActivityModel;
 
     static String SELECTED_TAB_KEY = "SELECTED_TAB";
+    static int queueSnapshots = 0;
 
     @Override
     public void onBackPressed() {
         ((AbstractTabbedFrag) getFragment(getClassForType(tabBarView.getSelected()))).onNavigateBack();
+    }
+
+    public static int getSnapshotQueue() {
+        return queueSnapshots;
     }
 
     private Class getClassForType(DashboardTab.TabType type) {
@@ -109,6 +132,10 @@ public class DashActivity extends AbstractFragSwitcherActivity implements Displa
                 .getApplicationComponent()
                 .inject(this);
 
+        mDashActivityModel = ViewModelProviders
+                .of(this, mViewModelFactory)
+                .get(DashActivityViewModel.class);
+
         setContentView(R.layout.activity_main);
         setFragmentContainer(R.id.dash_content);
 
@@ -133,6 +160,8 @@ public class DashActivity extends AbstractFragSwitcherActivity implements Displa
         rootView.setScrollingEnabled(true);
         ViewCompat.setNestedScrollingEnabled(rootView, false);
         mSyncManager.setDashActivity(this);
+
+        snapshotsRemainingToSync();
 
         //update last sync label when the sync manager updates
         mSyncManager.getProgress().observe(this, (value) -> {
@@ -175,6 +204,7 @@ public class DashActivity extends AbstractFragSwitcherActivity implements Displa
                     setSyncStatus(true, R.drawable.ic_dashtopbar_sync,
                             R.drawable.dashtopbar_synccircle);
                     mSyncLabel.setText(R.string.topbar_synclabel);
+                    queueSnapshots = 0;
                 }
             }
         });
@@ -245,6 +275,57 @@ public class DashActivity extends AbstractFragSwitcherActivity implements Displa
                 mSyncLabel.setText(getString(id, value, total));
             }
         });
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        snapshotsRemainingToSync();
+    }
+
+    private void snapshotsRemainingToSync() {
+        AsyncTask.execute(() -> {
+            List<Snapshot> snapshots = mDashActivityModel.getSnapshotRepository().getQueueSnapshots();
+            queueSnapshots = snapshots.size();
+
+            runOnUiThread(() -> {
+                validateStorageCapacity();
+            });
+        });
+    }
+
+    private void validateStorageCapacity() {
+        /**
+         * Depending on the amount of snapshots that haven't already been sync,
+         * a message will be display letting the user know how much have he reach
+         * this could be a toast or a popup*/
+        String message;
+        if(queueSnapshots >= AppConstants.MEDIUM_CAPACITY && queueSnapshots < AppConstants.HIGH_CAPACITY) {
+            message = getString(R.string.snapshots_limit_medium, (queueSnapshots*100)/AppConstants.MAXIMUM_CAPACITY);
+            Toast toast = Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG);
+            toast.show();
+
+        } else if (queueSnapshots > AppConstants.HIGH_CAPACITY && queueSnapshots < AppConstants.MAXIMUM_CAPACITY) {
+            message = getString(R.string.snapshots_limit_high,(queueSnapshots*100)/AppConstants.MAXIMUM_CAPACITY);
+            makeLimitDialog(message).show();
+
+        } else if (queueSnapshots >= AppConstants.MAXIMUM_CAPACITY) {
+            message = getString(R.string.snapshot_limit_reach);
+            makeLimitDialog(message).show();
+
+            mSyncLabel.setText(getString(R.string.sync_require));
+            setSyncStatus(true, R.drawable.ic_warning, 0);
+        }
+
+    }
+
+    private SweetAlertDialog makeLimitDialog(String message) {
+        SweetAlertDialog dialog = new SweetAlertDialog(this, SweetAlertDialog.WARNING_TYPE)
+                .setTitleText(getString(R.string.attention_title))
+                .setContentText(message)
+                .setConfirmText(getString(R.string.all_okay))
+                .setConfirmClickListener(SweetAlertDialog::dismissWithAnimation);
+        return dialog;
     }
 }
 

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/dashboard/DashActivity.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/dashboard/DashActivity.java
@@ -4,11 +4,8 @@ import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.transition.TransitionManager;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.animation.AnimationUtils;
@@ -20,26 +17,25 @@ import android.widget.Toast;
 import com.github.curioustechizen.ago.RelativeTimeTextView;
 import com.ontbee.legacyforks.cn.pedant.SweetAlert.SweetAlertDialog;
 
-import org.fundacionparaguaya.adviserplatform.data.local.SnapshotDao;
 import org.fundacionparaguaya.adviserplatform.data.model.Snapshot;
+import org.fundacionparaguaya.adviserplatform.data.remote.AuthenticationManager;
+import org.fundacionparaguaya.adviserplatform.data.repositories.SyncManager;
 import org.fundacionparaguaya.adviserplatform.injection.InjectionViewModelFactory;
+import org.fundacionparaguaya.adviserplatform.jobs.SyncJob;
+import org.fundacionparaguaya.adviserplatform.ui.base.AbstractTabbedFrag;
+import org.fundacionparaguaya.adviserplatform.ui.base.DisplayBackNavListener;
+import org.fundacionparaguaya.adviserplatform.ui.common.AbstractFragSwitcherActivity;
+import org.fundacionparaguaya.adviserplatform.ui.common.widget.NonScrollView;
+import org.fundacionparaguaya.adviserplatform.ui.families.FamilyTabbedFragment;
+import org.fundacionparaguaya.adviserplatform.ui.login.LoginActivity;
+import org.fundacionparaguaya.adviserplatform.ui.map.MapTabFrag;
+import org.fundacionparaguaya.adviserplatform.ui.settings.SettingsTabFrag;
+import org.fundacionparaguaya.adviserplatform.ui.social.SocialTabFrag;
 import org.fundacionparaguaya.adviserplatform.util.AppConstants;
+import org.fundacionparaguaya.adviserplatform.util.MixpanelHelper;
 import org.fundacionparaguaya.assistantadvisor.AdviserAssistantApplication;
 import org.fundacionparaguaya.assistantadvisor.BuildConfig;
 import org.fundacionparaguaya.assistantadvisor.R;
-import org.fundacionparaguaya.adviserplatform.ui.base.DisplayBackNavListener;
-import org.fundacionparaguaya.adviserplatform.ui.common.AbstractFragSwitcherActivity;
-import org.fundacionparaguaya.adviserplatform.ui.login.LoginActivity;
-import org.fundacionparaguaya.adviserplatform.data.remote.AuthenticationManager;
-import org.fundacionparaguaya.adviserplatform.jobs.SyncJob;
-import org.fundacionparaguaya.adviserplatform.data.repositories.SyncManager;
-import org.fundacionparaguaya.adviserplatform.ui.base.AbstractTabbedFrag;
-import org.fundacionparaguaya.adviserplatform.ui.common.widget.NonScrollView;
-import org.fundacionparaguaya.adviserplatform.ui.families.FamilyTabbedFragment;
-import org.fundacionparaguaya.adviserplatform.ui.settings.SettingsTabFrag;
-import org.fundacionparaguaya.adviserplatform.ui.map.MapTabFrag;
-import org.fundacionparaguaya.adviserplatform.ui.social.SocialTabFrag;
-import org.fundacionparaguaya.adviserplatform.util.MixpanelHelper;
 
 import java.util.List;
 
@@ -72,7 +68,7 @@ public class DashActivity extends AbstractFragSwitcherActivity implements Displa
     private DashActivityViewModel mDashActivityModel;
 
     static String SELECTED_TAB_KEY = "SELECTED_TAB";
-    static int queueSnapshots = 0;
+    private static int queueSnapshots = 0;
 
     @Override
     public void onBackPressed() {

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/dashboard/DashActivityViewModel.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/dashboard/DashActivityViewModel.java
@@ -1,0 +1,16 @@
+package org.fundacionparaguaya.adviserplatform.ui.dashboard;
+
+import android.arch.lifecycle.ViewModel;
+import org.fundacionparaguaya.adviserplatform.data.repositories.SnapshotRepository;
+
+public class DashActivityViewModel extends ViewModel {
+    private SnapshotRepository snapshotRepository;
+
+    public DashActivityViewModel(SnapshotRepository snapshotRepository) {
+        this.snapshotRepository = snapshotRepository;
+    }
+
+    public SnapshotRepository getSnapshotRepository() {
+        return snapshotRepository;
+    }
+}

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/families/AllFamiliesFragment.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/families/AllFamiliesFragment.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.test.espresso.remote.EspressoRemoteMessage;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -13,6 +14,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
+import android.widget.Toast;
+
+import org.fundacionparaguaya.adviserplatform.ui.dashboard.DashActivity;
+import org.fundacionparaguaya.adviserplatform.util.AppConstants;
 import org.fundacionparaguaya.assistantadvisor.AdviserAssistantApplication;
 import org.fundacionparaguaya.assistantadvisor.R;
 import org.fundacionparaguaya.adviserplatform.ui.survey.SurveyActivity;
@@ -94,13 +99,19 @@ public class AllFamiliesFragment extends AbstractStackedFrag {
         addButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Intent surveyIntent = new Intent(getContext(), SurveyActivity.class);
-                Bundle bundle = ActivityOptionsCompat.makeCustomAnimation(getContext(),
-                        android.R.anim.fade_in, android.R.anim.fade_out).toBundle();
+                if(DashActivity.getSnapshotQueue() >= AppConstants.MAXIMUM_CAPACITY) {
+                    Toast toast = Toast.makeText(getContext(), getString(R.string.survey_disable), Toast.LENGTH_LONG);
+                    toast.show();
+                } else {
+                    Intent surveyIntent = new Intent(getContext(), SurveyActivity.class);
+                    Bundle bundle = ActivityOptionsCompat.makeCustomAnimation(getContext(),
+                            android.R.anim.fade_in, android.R.anim.fade_out).toBundle();
 
-                startActivityForResult(surveyIntent, NEW_FAMILY_REQUEST, bundle);
+                    startActivityForResult(surveyIntent, NEW_FAMILY_REQUEST, bundle);
 
-                MixpanelHelper.SurveyEvents.newFamily(getContext());
+                    MixpanelHelper.SurveyEvents.newFamily(getContext());
+                }
+
             }
         });
     }

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/families/AllFamiliesFragment.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/families/AllFamiliesFragment.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.test.espresso.remote.EspressoRemoteMessage;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -16,16 +15,16 @@ import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.Toast;
 
-import org.fundacionparaguaya.adviserplatform.ui.dashboard.DashActivity;
-import org.fundacionparaguaya.adviserplatform.util.AppConstants;
-import org.fundacionparaguaya.assistantadvisor.AdviserAssistantApplication;
-import org.fundacionparaguaya.assistantadvisor.R;
-import org.fundacionparaguaya.adviserplatform.ui.survey.SurveyActivity;
-import org.fundacionparaguaya.adviserplatform.ui.families.detail.FamilyDetailFrag;
+import org.fundacionparaguaya.adviserplatform.injection.InjectionViewModelFactory;
 import org.fundacionparaguaya.adviserplatform.ui.base.AbstractStackedFrag;
+import org.fundacionparaguaya.adviserplatform.ui.dashboard.DashActivity;
+import org.fundacionparaguaya.adviserplatform.ui.families.detail.FamilyDetailFrag;
+import org.fundacionparaguaya.adviserplatform.ui.survey.SurveyActivity;
+import org.fundacionparaguaya.adviserplatform.util.AppConstants;
 import org.fundacionparaguaya.adviserplatform.util.MixpanelHelper;
 import org.fundacionparaguaya.adviserplatform.util.ScreenUtils;
-import org.fundacionparaguaya.adviserplatform.injection.InjectionViewModelFactory;
+import org.fundacionparaguaya.assistantadvisor.AdviserAssistantApplication;
+import org.fundacionparaguaya.assistantadvisor.R;
 
 import javax.inject.Inject;
 

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/util/AppConstants.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/util/AppConstants.java
@@ -22,7 +22,9 @@ public class AppConstants {
     public static final String RESIZE_IMAGE_SIZE = "200x200";
     public static final String USER_ROLE = "ROLE_SURVEY_USER";
     public static final String EMPTY_URL = "NONE";
-
+    public static final int MAXIMUM_CAPACITY = 1000;
+    public static final int MEDIUM_CAPACITY = (int) (MAXIMUM_CAPACITY * 0.5);
+    public static final int HIGH_CAPACITY = (int) (MAXIMUM_CAPACITY * 0.8);
 
     private AppConstants() {
         //Utilities classes don't have public constructors

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/util/AppConstants.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/util/AppConstants.java
@@ -21,6 +21,7 @@ public class AppConstants {
     public static final String BUCKET_ENDPOINT_2 = "http://py.org.fundacionparaguaya.psp.images.s3-website.eu-west-2.amazonaws.com/";
     public static final String RESIZE_IMAGE_SIZE = "200x200";
     public static final String USER_ROLE = "ROLE_SURVEY_USER";
+    public static final String EMPTY_URL = "NONE";
 
 
     private AppConstants() {

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/util/IndicatorUtilities.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/util/IndicatorUtilities.java
@@ -156,4 +156,19 @@ public class IndicatorUtilities {
     public static void setViewColorFromResponse(IndicatorOption option, View v) {
        setColorFromLevel(option.getLevel(), v);
     }
+
+    public static String generateUri(String imageUri) {
+        if (AppConstants.EMPTY_URL.equals(imageUri)) {
+            return AppConstants.EMPTY_URL;
+        }
+
+        String params[] = imageUri.split("images/");
+        String uri;
+        if ( params[0].equals(AppConstants.BUCKET_FPPSP) ) {
+            uri = AppConstants.BUCKET_ENDPOINT_1;
+        } else {
+            uri = AppConstants.BUCKET_ENDPOINT_2;
+        }
+        return uri + AppConstants.RESIZE_IMAGE_SIZE + "/" + params[1];
+    }
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -123,6 +123,13 @@
     <string name="cd_numberstepper_plus">Incrementar Valor</string>
     <string name="cd_numberstepper_minus">Decrementar Valor</string>
 
+    <!--App Limits-->
+    <string name="snapshots_limit_medium">Has alcanzado %d\%% de la capacidad para información de familias</string>
+    <string name="snapshots_limit_high">Has alcanzado %d\%% de la capacidad para información de familias. Busca una conexión de Internet estable para comenzar la sincronización</string>
+    <string name="snapshot_limit_reach">Has alcanzado el máximo de capacidad para información de familias. Busca una conexión de Internet estable para comenzar la sincronización</string>
+    <string name="survey_disable">La toma de encuestas está deshabilitada</string>
+    <string name="attention_title">Atención</string>
+
     <!-- Other -->
     <string name="spinner_placeholder">Seleccione una opcion&#8230;</string>
     <string name="familydetail_nullmember_title">Esta familia no puede ser encuestada</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -128,6 +128,7 @@
     <string name="snapshots_limit_high">Has alcanzado %d\%% de la capacidad para información de familias. Busca una conexión de Internet estable para comenzar la sincronización</string>
     <string name="snapshot_limit_reach">Has alcanzado el máximo de capacidad para información de familias. Busca una conexión de Internet estable para comenzar la sincronización</string>
     <string name="survey_disable">La toma de encuestas está deshabilitada</string>
+    <string name="sync_require">Sincronización requerida</string>
     <string name="attention_title">Atención</string>
 
     <!-- Other -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,14 @@
         are aware of the problem and will have it fixed soon. (Issue: #257)
     </string>
 
+    <!--App Limits-->
+    <string name="snapshots_limit_medium">You\'ve reached %d\%% of app capacity for families information</string>
+    <string name="snapshots_limit_high">You\'ve reached %.d\%% of app capacity for families information. Please reach for an stable internet connection to sync your data</string>
+    <string name="snapshot_limit_reach">You\'ve reached the maximum capacity for families information. Please reach for an stable internet connection to sync your data</string>
+    <string name="survey_disable">Survey taking is disable</string>
+    <string name="sync_require">Synchronization is require</string>
+    <string name="attention_title">Attention</string>
+
     <!-- Not Translated -->
     <string name="family_imagePlaceholder" translatable="false">
         https://s3.us-east-2.amazonaws.com/fp-psp-images/44-3.jpg

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,8 +137,8 @@
     <string name="snapshots_limit_medium">You\'ve reached %d\%% of app capacity for families information</string>
     <string name="snapshots_limit_high">You\'ve reached %.d\%% of app capacity for families information. Please reach for an stable internet connection to sync your data</string>
     <string name="snapshot_limit_reach">You\'ve reached the maximum capacity for families information. Please reach for an stable internet connection to sync your data</string>
-    <string name="survey_disable">Survey taking is disable</string>
-    <string name="sync_require">Synchronization is require</string>
+    <string name="survey_disable">No surveys allowed</string>
+    <string name="sync_require">Synchronization required</string>
     <string name="attention_title">Attention</string>
 
     <!-- Not Translated -->


### PR DESCRIPTION
If the defined limit for snapshots capacity is reached or close to been reached, a series of messages will be displayed to the user.

<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Description <!-- [OPTIONAL] -->
<!-- Include a short description of this pull request -->
`[EXAMPLE]` This adds a new page which will let an asesora view changes to a families red, yellow, green levels. It has some cool features which allow the asesora to browse a family's history and view trends.

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Displays messages for when the user reaches or is close to reach the maximum family information capacity.
- Disables the "survey" button and adds message of "Synchronization is requiere"

# Screenshots <!-- [IF APPLICABLE] -->
![screenshot_1535738197](https://user-images.githubusercontent.com/28272898/44985206-7a0fd280-af4d-11e8-85f1-ad419cb2b979.png)
![screenshot_1535738204](https://user-images.githubusercontent.com/28272898/44985219-85fb9480-af4d-11e8-9285-77bf9e5f5948.png)
![screenshot_1535742376](https://user-images.githubusercontent.com/28272898/44985232-927fed00-af4d-11e8-8d46-5622b5412966.png)


# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [x] Logged in to the application
  - [x] Fill out a snapshot for a new family
  - [x] Fill out a snapshot for an existing family
  - [x] Fill out priorities for a snapshot
  - [x] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [ ] API Level 22
  - [x] API Level 25
- Screen Size:
  - [x] 7" screen size
  - [ ] 8" screen size
  - [ ] 10" screen size
