### PR TITLE
Minor fixup in storage limits

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/dashboard/DashActivity.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/dashboard/DashActivity.java
@@ -118,6 +118,8 @@ public class DashActivity extends AbstractFragSwitcherActivity implements Displa
         TransitionManager.beginDelayedTransition(findViewById(R.id.dashboardtopbar));
         mBackButton.setVisibility(frag.isBackNavRequired()? View.VISIBLE: View.GONE);
         mTvTabTitle.setVisibility(frag.isBackNavRequired()? View.GONE: View.VISIBLE);
+
+        snapshotsRemainingToSync();
     }
 
     @Override
@@ -156,8 +158,6 @@ public class DashActivity extends AbstractFragSwitcherActivity implements Displa
         rootView.setScrollingEnabled(true);
         ViewCompat.setNestedScrollingEnabled(rootView, false);
         mSyncManager.setDashActivity(this);
-
-        snapshotsRemainingToSync();
 
         //update last sync label when the sync manager updates
         mSyncManager.getProgress().observe(this, (value) -> {
@@ -301,7 +301,7 @@ public class DashActivity extends AbstractFragSwitcherActivity implements Displa
             Toast toast = Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG);
             toast.show();
 
-        } else if (queueSnapshots > AppConstants.HIGH_CAPACITY && queueSnapshots < AppConstants.MAXIMUM_CAPACITY) {
+        } else if (queueSnapshots >= AppConstants.HIGH_CAPACITY && queueSnapshots < AppConstants.MAXIMUM_CAPACITY) {
             message = getString(R.string.snapshots_limit_high,(queueSnapshots*100)/AppConstants.MAXIMUM_CAPACITY);
             makeLimitDialog(message).show();
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,7 +135,7 @@
 
     <!--App Limits-->
     <string name="snapshots_limit_medium">You\'ve reached %d\%% of app capacity for families information</string>
-    <string name="snapshots_limit_high">You\'ve reached %.d\%% of app capacity for families information. Please reach for an stable internet connection to sync your data</string>
+    <string name="snapshots_limit_high">You\'ve reached %d\%% of app capacity for families information. Please reach for an stable internet connection to sync your data</string>
     <string name="snapshot_limit_reach">You\'ve reached the maximum capacity for families information. Please reach for an stable internet connection to sync your data</string>
     <string name="survey_disable">No surveys allowed</string>
     <string name="sync_require">Synchronization required</string>


### PR DESCRIPTION
Move method from `onCreate` to `switchToFrag` in `DashActivity` in order to increase
the amount of times it checks wheater the limits had been reached or not.

Also fixed a misspelling in a string.

<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Description <!-- [OPTIONAL] -->
<!-- Include a short description of this pull request -->
`[EXAMPLE]` This adds a new page which will let an asesora view changes to a families red, yellow, green levels. It has some cool features which allow the asesora to browse a family's history and view trends.

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Corrected a misspelling in one of the user messages.
- Increased the amount of times the function that checks the storage capacity is trigger.

# Issues <!-- [IF APPLICABLE] -->
<!-- Fill in a bulleted list with issues that have been introduced or fixed -->
- Fixes
  - `[EXAMPLE]` Fixes #39 by adding the visualization of red, yellow, green levels
- Introduces
  - `[EXAMPLE]` Introduces #45; the graph will dissapear when rotated on API 19

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [x] Logged in to the application
  - [x] Fill out a snapshot for a new family
  - [x] Fill out a snapshot for an existing family
  - [x] Fill out priorities for a snapshot
  - [x] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [] API Level 22
  - [x] API Level 25
- Screen Size:
  - [x] 7" screen size
  - [ ] 8" screen size
  - [ ] 10" screen size
